### PR TITLE
typo: hisotry -> history

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -449,7 +449,7 @@
                         alt
                     />
                     <div class="message">
-                        <h3>{{ _("No Hisotry Searches Found") }}</h3>
+                        <h3>{{ _("No History Searches Found") }}</h3>
                         <p>
                             {{ _("It seems like you haven’t searched for any
                             songs yet. No worries, your musical journey can

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -560,7 +560,7 @@ msgid "Reload Page"
 msgstr "Przeładuj stronę"
 
 #: templates/index.html:450
-msgid "No Hisotry Searches Found"
+msgid "No History Searches Found"
 msgstr "Brak historii wyszukiwania"
 
 #: templates/index.html:452

--- a/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -545,7 +545,7 @@ msgid "Reload Page"
 msgstr "重新載入頁面"
 
 #: templates/index.html:450
-msgid "No Hisotry Searches Found"
+msgid "No History Searches Found"
 msgstr "未找到歷史搜索"
 
 #: templates/index.html:452


### PR DESCRIPTION
pretty straightforward.
fixes a small typo I noticed while looking at the main menu.

![image](https://github.com/user-attachments/assets/193a4fc8-32b9-40d5-9102-c550ec0653a3)
